### PR TITLE
Updated all packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN git --version \
     && jq --version
 
 # Install shellcheck
+# @see https://github.com/koalaman/shellcheck/releases
 ENV SHELLCHECK_VERSION=0.7.0
 RUN curl -L -o "/tmp/shellcheck-v${SHELLCHECK_VERSION}.tar.xz" "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
   && tar --xz -xvf "/tmp/shellcheck-v${SHELLCHECK_VERSION}.tar.xz" \
@@ -24,8 +25,10 @@ RUN curl -L -o "/tmp/shellcheck-v${SHELLCHECK_VERSION}.tar.xz" "https://storage.
   && shellcheck --version
 
 # Install docker && docker compose.
-ENV DOCKER_VERSION=18.09.2
-ENV DOCKER_COMPOSE_VERSION=1.23.2
+# @see https://download.docker.com/linux/static/stable/x86_64
+# @see https://github.com/docker/compose/releases
+ENV DOCKER_VERSION=19.03.5
+ENV DOCKER_COMPOSE_VERSION=1.25.1
 RUN curl -L -o "/tmp/docker-${DOCKER_VERSION}.tgz" "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
     && tar -xz -C /tmp -f "/tmp/docker-${DOCKER_VERSION}.tgz" \
     && mv /tmp/docker/* /usr/bin \
@@ -35,8 +38,9 @@ RUN curl -L -o "/tmp/docker-${DOCKER_VERSION}.tgz" "https://download.docker.com/
     && docker-compose --version
 
 # Install composer.
-ENV COMPOSER_VERSION=1.8.6
-ENV COMPOSER_SHA=b66f9b53db72c5117408defe8a1e00515fe749e97ce1b0ae8bdaa6a5a43dd542
+# @see https://getcomposer.org/download
+ENV COMPOSER_VERSION=1.9.1
+ENV COMPOSER_SHA=1f210b9037fcf82670d75892dfc44400f13fe9ada7af9e787f93e50e3b764111
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN curl -L -o "/usr/local/bin/composer" "https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar" \
     && echo "${COMPOSER_SHA} /usr/local/bin/composer" | sha256sum \
@@ -48,10 +52,11 @@ RUN curl -L -o "/usr/local/bin/composer" "https://getcomposer.org/download/${COM
 ENV PATH /root/.composer/vendor/bin:$PATH
 
 # Install NVM and NodeJS.
-ENV NVM_VERSION=v0.34.0
+# @see https://github.com/nvm-sh/nvm/releases
+ENV NVM_VERSION=v0.35.2
 ENV NVM_DIR=/root/.nvm
 RUN mkdir -p "${NVM_DIR}" \
-  && curl -o- "https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh" | bash \
+  && curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh" | bash \
   && . $HOME/.nvm/nvm.sh \
   && nvm --version
 
@@ -69,6 +74,7 @@ RUN curl -fsSL https://goss.rocks/install | sh \
   && goss --version
 
 # Install Bats.
+# @see https://github.com/bats-core/bats-core/releases
 ENV BATS_VERSION=v1.1.0
 RUN curl -L -o "/tmp/bats.tar.gz" "https://github.com/bats-core/bats-core/archive/${BATS_VERSION}.tar.gz" \
     && mkdir -p /tmp/bats && tar -xz -C /tmp/bats -f /tmp/bats.tar.gz --strip 1 \
@@ -78,6 +84,7 @@ RUN curl -L -o "/tmp/bats.tar.gz" "https://github.com/bats-core/bats-core/archiv
     && rm -Rf /tmp/bats
 
 # Install Ahoy.
+# @see https://github.com/ahoy-cli/ahoy/releases
 ENV AHOY_VERSION=2.0.0
 RUN curl -L -o "/usr/local/bin/ahoy" "https://github.com/ahoy-cli/ahoy/releases/download/${AHOY_VERSION}/ahoy-bin-$(uname -s)-amd64" \
   && chmod +x /usr/local/bin/ahoy \

--- a/goss.yaml
+++ b/goss.yaml
@@ -99,13 +99,6 @@ command:
     stderr: []
     timeout: 10000
 
-  npm --version:
-    exit-status: 0
-    stdout:
-    - 6.4.1
-    stderr: []
-    timeout: 10000
-
   which ahoy:
     exit-status: 0
     stdout:
@@ -138,13 +131,6 @@ command:
     exit-status: 0
     stdout:
       - /usr/local/bin/bats
-    stderr: []
-    timeout: 10000
-
-  bats -v:
-    exit-status: 0
-    stdout:
-      - Bats 1.1.0
     stderr: []
     timeout: 10000
 


### PR DESCRIPTION
```
----------------------------------------
git
----------------------------------------
git version 2.20.1
----------------------------------------

----------------------------------------
ssh
----------------------------------------
OpenSSH_7.9p1 Debian-10+deb10u1, OpenSSL 1.1.1d  10 Sep 2019
----------------------------------------

----------------------------------------
lsof
----------------------------------------
lsof version information:
    revision: 4.91
    latest revision: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/
    latest FAQ: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/FAQ
    latest man page: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_man
    compiler: cc
    compiler version: 8.2.0 (Debian 8.2.0-14) 
    compiler flags: -g -O2 -fdebug-prefix-map=/lsof_4.91_src=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -DLINUXV=419013 -DGLIBCV=228 -DHASIPv6 -DNEEDS_NETINET_TCPH -DHASSELINUX -DHASUXSOCKEPT -DHASPTYEPT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DHAS_STRFTIME -DLSOF_VSTR="4.19.13" -O
    loader flags: -L./lib -llsof -Wl,-z,relro -Wl,-z,now -lselinux
    Anyone can list all files.
    /dev warnings are disabled.
    Kernel ID check is disabled.
----------------------------------------

----------------------------------------
zip
----------------------------------------
Copyright (c) 1990-2008 Info-ZIP - Type 'zip "-L"' for software license.
This is Zip 3.0 (July 5th 2008), by Info-ZIP.
Currently maintained by E. Gordon.  Please send bug reports to
the authors using the web page at www.info-zip.org; see README for details.

Latest sources and executables are at ftp://ftp.info-zip.org/pub/infozip,
as of above date; see http://www.info-zip.org/ for other sites.

Compiled with gcc 6.3.0 20170221 for Unix (Linux ELF).

Zip special compilation options:
	USE_EF_UT_TIME       (store Universal Time)
	BZIP2_SUPPORT        (bzip2 library version 1.0.6, 6-Sept-2010)
	    bzip2 code and library copyright (c) Julian R Seward
	    (See the bzip2 license for terms of use)
	SYMLINK_SUPPORT      (symbolic links supported)
	LARGE_FILE_SUPPORT   (can read and write large files on file system)
	ZIP64_SUPPORT        (use Zip64 to store large files in archives)
	UNICODE_SUPPORT      (store and read UTF-8 Unicode paths)
	STORE_UNIX_UIDs_GIDs (store UID/GID sizes/values using new extra field)
	UIDGID_NOT_16BIT     (old Unix 16-bit UID/GID extra field not used)
	[encryption, version 2.91 of 05 Jan 2007] (modified for Zip 3)

Encryption notice:
	The encryption code of this program is not copyrighted and is
	put in the public domain.  It was originally written in Europe
	and, to the best of our knowledge, can be freely distributed
	in both source and object forms from any country, including
	the USA under License Exception TSU of the U.S. Export
	Administration Regulations (section 740.13(e)) of 6 June 2002.

Zip environment options:
             ZIP:  [none]
          ZIPOPT:  [none]
----------------------------------------

----------------------------------------
unzip
----------------------------------------
UnZip 6.00 of 20 April 2009, by Debian. Original by Info-ZIP.

Latest sources and executables are at ftp://ftp.info-zip.org/pub/infozip/ ;
see ftp://ftp.info-zip.org/pub/infozip/UnZip.html for other sites.

Compiled with gcc 8.3.0 for Unix (Linux ELF).

UnZip special compilation options:
        ACORN_FTYPE_NFS
        COPYRIGHT_CLEAN (PKZIP 0.9x unreducing method not supported)
        SET_DIR_ATTRIB
        SYMLINKS (symbolic links supported, if RTL and file system permit)
        TIMESTAMP
        UNIXBACKUP
        USE_EF_UT_TIME
        USE_UNSHRINK (PKZIP/Zip 1.x unshrinking method supported)
        USE_DEFLATE64 (PKZIP 4.x Deflate64(tm) supported)
        UNICODE_SUPPORT [wide-chars, char coding: other] (handle UTF-8 paths)
        LARGE_FILE_SUPPORT (large files over 2 GiB supported)
        ZIP64_SUPPORT (archives using Zip64 for large files supported)
        USE_BZIP2 (PKZIP 4.6+, using bzip2 lib version 1.0.6, 6-Sept-2010)
        VMS_TEXT_CONV
        WILD_STOP_AT_DIR
        [decryption, version 2.11 of 05 Jan 2007]

UnZip and ZipInfo environment options:
           UNZIP:  [none]
        UNZIPOPT:  [none]
         ZIPINFO:  [none]
      ZIPINFOOPT:  [none]
----------------------------------------

----------------------------------------
vim
----------------------------------------
VIM - Vi IMproved 8.1 (2018 May 18, compiled Jun 15 2019 16:41:15)
Included patches: 1-875, 878, 884, 948, 1046, 1365-1368, 1382, 1401
Modified by team+vim@tracker.debian.org
Compiled by team+vim@tracker.debian.org
Huge version without GUI.  Features included (+) or not (-):
+acl               +extra_search      +mouse_netterm     +tag_old_static
+arabic            +farsi             +mouse_sgr         -tag_any_white
+autocmd           +file_in_path      -mouse_sysmouse    -tcl
+autochdir         +find_in_path      +mouse_urxvt       +termguicolors
-autoservername    +float             +mouse_xterm       +terminal
-balloon_eval      +folding           +multi_byte        +terminfo
+balloon_eval_term -footer            +multi_lang        +termresponse
-browse            +fork()            -mzscheme          +textobjects
++builtin_terms    +gettext           +netbeans_intg     +textprop
+byte_offset       -hangul_input      +num64             +timers
+channel           +iconv             +packages          +title
+cindent           +insert_expand     +path_extra        -toolbar
-clientserver      +job               -perl              +user_commands
-clipboard         +jumplist          +persistent_undo   +vartabs
+cmdline_compl     +keymap            +postscript        +vertsplit
+cmdline_hist      +lambda            +printer           +virtualedit
+cmdline_info      +langmap           +profile           +visual
+comments          +libcall           -python            +visualextra
+conceal           +linebreak         -python3           +viminfo
+cryptv            +lispindent        +quickfix          +vreplace
+cscope            +listcmds          +reltime           +wildignore
+cursorbind        +localmap          +rightleft         +wildmenu
+cursorshape       -lua               -ruby              +windows
+dialog_con        +menu              +scrollbind        +writebackup
+diff              +mksession         +signs             -X11
+digraphs          +modify_fname      +smartindent       -xfontset
-dnd               +mouse             +startuptime       -xim
-ebcdic            -mouseshape        +statusline        -xpm
+emacs_tags        +mouse_dec         -sun_workshop      -xsmp
+eval              +mouse_gpm         +syntax            -xterm_clipboard
+ex_extra          -mouse_jsbterm     +tag_binary        -xterm_save
   system vimrc file: "$VIM/vimrc"
     user vimrc file: "$HOME/.vimrc"
 2nd user vimrc file: "~/.vim/vimrc"
      user exrc file: "$HOME/.exrc"
       defaults file: "$VIMRUNTIME/defaults.vim"
  fall-back for $VIM: "/usr/share/vim"
Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H   -Wdate-time  -g -O2 -fdebug-prefix-map=/build/vim-4Pursk/vim-8.1.0875=. -fstack-protector-strong -Wformat -Werror=format-security -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1       
Linking: gcc   -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -o vim        -lm -ltinfo -lnsl  -lselinux -lacl -lattr -lgpm -ldl           
----------------------------------------

----------------------------------------
lynx
----------------------------------------
Lynx Version 2.8.9rel.1 (08 Jul 2018)
libwww-FM 2.14, SSL-MM 1.4.1, GNUTLS 3.6.5, ncurses 6.1.20181013(wide)
Built on linux-gnu.

Copyrights held by the Lynx Developers Group,
the University of Kansas, CERN, and other contributors.
Distributed under the GNU General Public License (Version 2).
See https://lynx.invisible-island.net/ and the online help for more information.


----------------------------------------

----------------------------------------
curl
----------------------------------------
curl 7.64.0 (x86_64-pc-linux-gnu) libcurl/7.64.0 OpenSSL/1.1.1d zlib/1.2.11 libidn2/2.0.5 libpsl/0.20.2 (+libidn2/2.0.5) libssh2/1.8.0 nghttp2/1.36.0 librtmp/2.3
Release-Date: 2019-02-06
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp 
Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP HTTP2 UnixSockets HTTPS-proxy PSL 
----------------------------------------

----------------------------------------
aspell
----------------------------------------
@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.7-20110707)
----------------------------------------

----------------------------------------
jq
----------------------------------------
jq-1.5-1-a5b5cbe
----------------------------------------

----------------------------------------
shellcheck
----------------------------------------
ShellCheck - shell script analysis tool
version: 0.7.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
----------------------------------------

----------------------------------------
docker
----------------------------------------
Docker version 19.03.5, build 633a0ea838
----------------------------------------

----------------------------------------
docker-compose
----------------------------------------
docker-compose version 1.25.1, build a82fef07
----------------------------------------

----------------------------------------
php
----------------------------------------
PHP 7.2.26 (cli) (built: Dec 28 2019 22:04:49) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
----------------------------------------

----------------------------------------
composer
----------------------------------------
Composer version 1.9.1 2019-11-01 17:20:17
----------------------------------------

----------------------------------------
npm
----------------------------------------
6.4.1
----------------------------------------

----------------------------------------
npx
----------------------------------------
6.4.1
----------------------------------------

----------------------------------------
node
----------------------------------------
v8.16.0
----------------------------------------

----------------------------------------
goss
----------------------------------------
goss version v0.3.9
----------------------------------------

----------------------------------------
bats
----------------------------------------
Bats 1.1.0
----------------------------------------

----------------------------------------
ahoy
----------------------------------------
2.0.0
----------------------------------------

```